### PR TITLE
Add requirements for Windows 10 and Server 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@
 
 ## Documentation
 For more information on what functions are available visit this page: https://playnet-public.github.io/ArmA3URLFetch/html .
+
+## Requirements
+
+### Windows 10 / Server 2016
+
+You need to install the Visual C++ Redistributable for Visual Studio 2015 when using Windows 10 or Windows Server 2016. 
+https://www.microsoft.com/en-US/download/details.aspx?id=48145


### PR DESCRIPTION
On vanilla installations of Windows 10 and Server 2016 there is no VC++ 2015 redist package installed therefor the dll can not be loaded and calling the extension fails with an error in the .rpt file. 

This is due the compilation of CURL with VC++ 2015 which links against MSVCP140.dll